### PR TITLE
Fixed error when only one FastQ file is selected

### DIFF
--- a/src/req/renderer/AlignRenderer/reportView.js
+++ b/src/req/renderer/AlignRenderer/reportView.js
@@ -151,18 +151,18 @@ module.exports  = function(arr,div,model)
                 }
                 if(event.target.id == "alignButton")
                 {
-                    var q_count = 0;
+                    var selected_fastq_count = 0;
                     for(let i = 0; i != this.data.fastqInputs.length; ++i)
                     {
                         if(this.data.selectedFastqs[0] == this.data.fastqInputs[i].validID)
                         {
                             this.data.selectedFastqs[0] = this.data.fastqInputs[i];
-                            q_count++;
+                            selected_fastq_count++;
                         }
                         if(this.data.selectedFastqs[1] == this.data.fastqInputs[i].validID)
                         {
                             this.data.selectedFastqs[1] = this.data.fastqInputs[i];
-                            q_count++;
+                            selected_fastq_count++;
                             break;
                         }
                     }
@@ -179,11 +179,11 @@ module.exports  = function(arr,div,model)
                         Only run the alignment (bowtie2) if two fastQ's have been selected, 
                         AND a Fasta has been selected.
                     */
-                    if (this.data.selectedFasta != "" && q_count >= 2) {
+                    if (this.data.selectedFasta != "" && selected_fastq_count >= 2) {
                         alert("P.H.A.T will now align your selection.\nThis may take a few minutes.")
                         this.model.runAlignment(this.data.selectedFastqs,this.data.selectedFasta,this.data.tab);
                     } else {
-                        alert(q_count >= 2 ? "You need to select a Fasta file!" : "You need to select two FastQ files!");
+                        alert(selected_fastq_count >= 2 ? "You need to select a Fasta file!" : "You need to select two FastQ files!");
                     }
                 }
                 this.populateSelectedFasta();


### PR DESCRIPTION
When only one is selected and you pressed align, an error would be thrown. Now it is fixed. Also added an alert to inform you that the program is doing an alignment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chgibb/phat/137)
<!-- Reviewable:end -->
